### PR TITLE
d&i LaTeX strings for vertices, arrows and quiver algebra elements

### DIFF
--- a/examples/latex_strings.g
+++ b/examples/latex_strings.g
@@ -1,0 +1,23 @@
+#! @BeginChunk Example_LaTeX_RightQuiver
+#! @BeginExample
+Q := RightQuiver( "Q(3)[alpha:1->2,beta:2->3,gamma:1->3]" );
+#! Q(3)[alpha:1->2,beta:2->3,gamma:1->3]
+SetLabelsAsLaTeXStrings( Q, 
+            [ "V_1", "V_2", "V_3" ],
+            [ "\\alpha", "\\beta", "\\gamma" ]
+          );
+kQ := PathAlgebra( Rationals, Q );
+#! Rationals * Q
+LabelAsLaTeXString( Q.1 );
+#! "V_1"
+e := 1/2 * kQ.alpha * kQ.beta - kQ.gamma + kQ.1;
+#! 1/2*(alpha*beta) - 1*(gamma) + 1*(1)
+LaTeXStringForQPA( e );
+#! "\\frac{1}{2}{\\alpha\\beta}-{\\gamma}+{V_1}"
+LaTeXStringForQPA( e : MultiplicationSymbol := "*" );
+#! "\\frac{1}{2}{\\alpha{*}\\beta}-{\\gamma}+{V_1}"
+LaTeXStringForQPA( e : MultiplicationSymbol := "*",
+                       ScalarMultiplicationSymbol := "\\cdot" );
+#! "\\frac{1}{2}\\cdot{\\alpha{*}\\beta}-{\\gamma}+{V_1}"
+#! @EndExample
+#! @EndChunk

--- a/lib/algebra.gd
+++ b/lib/algebra.gd
@@ -377,6 +377,17 @@ DeclareOperation( "CoefficientsOfPaths", [ IsList, IsQuiverAlgebraElement ] );
 #! @Label
 DeclareOperation( "CoefficientsOfPathsSorted", [ IsList, IsQuiverAlgebraElement ] );
 
+#! @Arguments e
+#! @Description
+#!  The operation uses the attribute <C>LabelAsLaTeXString</C> of primitive paths to compute
+#!  a LaTeX string for the algebra element <A>e</A>. One can pass optional values for <A>MultiplicationSymbol</A>
+#!  to specify the multiplication-symbol between the arrows of the paths, and <A>ScalarMultiplicationSymbol</A>
+#!  to specify the multiplication-symbol between scalars and paths.
+#! @Returns <C>IsString</C>
+DeclareOperation( "LaTeXStringForQPA", [ IsQuiverAlgebraElement ] );
+
+#! @InsertChunk Example_LaTeX_RightQuiver
+
 #! @Subsection Example
 
 #! Here is an example demonstrating use of the above functions:

--- a/lib/algebra.gi
+++ b/lib/algebra.gi
@@ -136,6 +136,88 @@ function( e )
   return e!.paths;
 end );
 
+# for the coefficients rings (similar to homalg rings)
+# fallback method
+#
+InstallOtherMethod( LaTeXStringForQPA,
+          [ IsRingElement ],
+  String
+);
+
+## for the field of rationals
+##
+InstallOtherMethod( LaTeXStringForQPA,
+          [ IsRat ],
+  function( r )
+    local n, d, s, l;
+    
+    n := NumeratorRat( r );
+    d := DenominatorRat( r );
+    
+    if IsOne( d ) then
+      return String( n );
+    fi;
+    
+    s := SignInt( n );
+    n := AbsInt( n );
+    
+    l := Concatenation( "\\frac{", String( n ), "}{", String( d ), "}" );
+    
+    if s = -1 then
+      l := Concatenation( "-", l );
+    fi;
+    
+    return l;
+    
+end );
+
+InstallMethod( LaTeXStringForQPA,
+          [ IsQuiverAlgebraElement ],
+  function( e )
+    local coeffs, paths, prod, string;
+    
+    if not IsPathAlgebraElement( e ) then
+      
+      e := Representative( e );
+      
+    fi;
+    
+    coeffs := List( Coefficients( e ), LaTeXStringForQPA );
+    
+    if IsEmpty( coeffs ) then
+      
+      return "0";
+      
+    elif coeffs[ 1 ] = "1" then
+      
+      coeffs[ 1 ] := "";
+      
+    fi;
+        
+    paths := List( Paths( e ), LaTeXStringForQPA );
+    
+    prod := ValueOption( "ScalarMultiplicationSymbol" );
+    
+    if prod = fail or not IsString( prod ) then
+      
+      prod := "";
+      
+    fi;
+    
+    string := ListN( coeffs, paths, { c, p } -> Concatenation( c, prod, "{", p, "}" ) );
+    
+    string := JoinStringsWithSeparator( string, "+" );
+    
+    string := ReplacedString( string, "+-", "-" );
+    
+    string := ReplacedString( string, Concatenation( "-1", prod, "{" ), "-{" );
+    
+    string := ReplacedString( string, Concatenation( "+1", prod, "{" ), "+{" );
+    
+    return string;
+    
+end );
+
 InstallMethod( IsLeftUniform, "for element of quiver algebra",
                [ IsQuiverAlgebraElement ],
 function( e )

--- a/lib/quiver.gd
+++ b/lib/quiver.gd
@@ -545,6 +545,14 @@ DeclareAttribute( "LabelAsLaTeXString", IsPrimitivePath );
 #!   the vertices and arrows.
 DeclareOperation( "SetLabelsAsLaTeXStrings", [ IsQuiver, IsList, IsList ] );
 
+#! @Arguments p
+#! @Description
+#!  The operation uses the attribute <C>LabelAsLaTeXString</C> of primitive paths to compute
+#!  a LaTeX string for the path <A>p</A>. One can pass an optional value for <A>MultiplicationSymbol</A>
+#!  to specify the multiplication-symbol between the arrows of the path.
+#! @Returns <C>IsString</C>
+DeclareOperation( "LaTeXStringForQPA", [ IsPath ] );
+
 DeclareAttribute( "ArrowString", IsArrow );
 
 DeclareGlobalFunction( "QPA_LABEL_TO_STRING" );

--- a/lib/quiver.gd
+++ b/lib/quiver.gd
@@ -531,6 +531,20 @@ DeclareAttribute( "Label", IsPrimitivePath );
 #! @Returns <C>IsString</C>
 DeclareAttribute( "LabelAsString", IsPrimitivePath );
 
+#! @Arguments p
+#! @Description
+#!  The label of the primitive path <A>p</A>, as a LaTeX string (without enclosing dollar signs).
+#!  The fallback method for this operation is <C>LabelAsString</C>.
+#! @Returns <C>IsString</C>
+DeclareAttribute( "LabelAsLaTeXString", IsPrimitivePath );
+
+#! @Arguments Q, vertices, arrows
+#! @Description
+#!   The arguments are a quiver <A>Q</A> and two lists <A>vertices</A> and <A>arrows</A> of LaTeX strings for
+#!   vertices resp. arrows. The operation uses these lists to set the attribute <C>LabelAsLaTeXString</C> for
+#!   the vertices and arrows.
+DeclareOperation( "SetLabelsAsLaTeXStrings", [ IsQuiver, IsList, IsList ] );
+
 DeclareAttribute( "ArrowString", IsArrow );
 
 DeclareGlobalFunction( "QPA_LABEL_TO_STRING" );

--- a/lib/quiver.gi
+++ b/lib/quiver.gi
@@ -594,6 +594,60 @@ function( v )
   return v!.label;
 end );
 
+## fallback method
+InstallMethod( LabelAsLaTeXString,
+          [ IsPrimitivePath ],
+  LabelAsString
+);
+
+##
+InstallMethod( SetLabelsAsLaTeXStrings,
+          [ IsQuiver, IsList, IsList ],
+  function( quiver, vertices_labels, arrows_labels )
+    local vertices, n, arrows, i;
+    
+    vertices := Vertices( quiver );
+    
+    n := NumberOfVertices( quiver );
+    
+    for i in [ 1 .. n ] do
+      
+      SetLabelAsLaTeXString( vertices[ i ], vertices_labels[ i ] );
+      
+    od;
+    
+    arrows := Arrows( quiver );
+    
+    n := NumberOfArrows( quiver );
+    
+    for i in [ 1 .. n ] do
+      
+      SetLabelAsLaTeXString( arrows[ i ], arrows_labels[ i ] );
+      
+    od;
+    
+end );
+
+## For example when the vertices are integers, then
+## latex_string by the fallback method is the same as LabelAsString
+##
+InstallOtherMethod( SetLabelsAsLaTeXStrings,
+          [ IsQuiver, IsList ],
+  function( quiver, arrows_labels )
+    local arrows, n, i;
+    
+    arrows := Arrows( quiver );
+    
+    n := NumberOfArrows( quiver );
+    
+    for i in [ 1 .. n ] do
+      
+      SetLabelAsLaTeXString( arrows[ i ], arrows_labels[ i ] );
+      
+    od;
+    
+end );
+
 InstallMethod( TranslatePath,
                [ IsPrimitivePath, IsFunction ],
 function( p, f )

--- a/lib/quiver.gi
+++ b/lib/quiver.gi
@@ -648,6 +648,34 @@ InstallOtherMethod( SetLabelsAsLaTeXStrings,
     
 end );
 
+##
+InstallMethod( LaTeXStringForQPA,
+          [ IsPrimitivePath ],
+  LabelAsLaTeXString
+);
+
+##
+InstallMethod( LaTeXStringForQPA,
+          [ IsPath ],
+  function( path )
+    local prod;
+    
+    prod := ValueOption( "MultiplicationSymbol" );
+    
+    if prod = fail or not IsString( prod ) then
+      
+      prod := "";
+      
+    else
+      
+      prod := Concatenation( "{", prod, "}" );
+      
+    fi;
+    
+    return JoinStringsWithSeparator( List( AsListLR( path ), LaTeXStringForQPA ), prod );
+    
+end );
+
 InstallMethod( TranslatePath,
                [ IsPrimitivePath, IsFunction ],
 function( p, f )


### PR DESCRIPTION
In this PR I declare & install the following:
* Attribute `LabelAsLaTeXString` for vertices and arrows
* Operation `SetLabelsAsLaTeXStrings` that sets these attributes to vertices and arrows.
* Operation `LaTeXStringForQPA` which computes a LaTeX strings for paths and algebra elements.

After this PR we can for example do the following:
```
gap> Q := RightQuiver( "Q(3)[alpha:1->2,beta:2->3,gamma:1->3]" );
#! Q(3)[alpha:1->2,beta:2->3,gamma:1->3]
gap> SetLabelsAsLaTeXStrings( Q, 
            [ "V_1", "V_2", "V_3" ],
            [ "\\alpha", "\\beta", "\\gamma" ]
          );
gap> kQ := PathAlgebra( Rationals, Q );
#! Rationals * Q
gap> LabelAsLaTeXString( Q.1 );
#! "V_1"
gap> e := 1/2 * kQ.alpha * kQ.beta - kQ.gamma + kQ.1;
#! 1/2*(alpha*beta) - 1*(gamma) + 1*(1)

gap> LaTeXStringForQPA( e );
#! "\\frac{1}{2}{\\alpha\\beta}-{\\gamma}+{V_1}"

gap> LaTeXStringForQPA( e : MultiplicationSymbol := "*" );
#! "\\frac{1}{2}{\\alpha{*}\\beta}-{\\gamma}+{V_1}"

gap> LaTeXStringForQPA( e : MultiplicationSymbol := "*", ScalarMultiplicationSymbol := "\\cdot" );
#! "\\frac{1}{2}\\cdot{\\alpha{*}\\beta}-{\\gamma}+{V_1}"
```

Using these operation we can install also latex strings methods for [Algebroids](https://github.com/homalg-project/Algebroids) (which turns a quiver algebra into a k-linear category with finitely many objects); and for [QuiverRows](https://github.com/homalg-project/CAP_project/blob/master/FreydCategoriesForCAP/gap/QuiverRows.gi) which is a model for the additive closure of an algebroid.