### PR TITLE
Adapt to https://github.com/homalg-project/CAP_project/pull/723

### DIFF
--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -883,8 +883,10 @@ end );
 InstallMethod( CategoryOfQuiverRepresentations, "for quiver algebra",
                [ IsQuiverAlgebra ],
 function( A )
+  local underlying_category_for_representations;
+  underlying_category_for_representations := UnderlyingCategoryForRepresentations( A : FinalizeCategory := true );
   return CategoryOfQuiverRepresentationsOverVectorSpaceCategory
-         ( A, UnderlyingCategoryForRepresentations( A ) );
+         ( A, underlying_category_for_representations );
 end );
 
 InstallMethod( \=, [ IsQuiverRepresentationCategory, IsQuiverRepresentationCategory ],


### PR DESCRIPTION
After CAP PR https://github.com/homalg-project/CAP_project/pull/723, every
category supports the option `FinalizeCategory` automatically. This means
that every category constructor must set `FinalizeCategory := true` if it
creates "child" categories to make sure those are finalized regardless of
the option given to the category constructor itself.

cc @kamalsaleh