### PR TITLE
Use CokernelObjectFunctorial instead of CokernelFunctorial

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -47,7 +47,7 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := "4.5",
-  NeededOtherPackages := [ [ "CAP", ">=2020.02.16" ],
+  NeededOtherPackages := [ [ "CAP", ">=2022.05-04" ],
                            [ "ComplexesCategories", ">=2020.07.24" ]
                            ],
   SuggestedOtherPackages := [],

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -1011,7 +1011,7 @@ function( A, vecspace_cat )
   coker := function( m )
     local map_for_arrow;
     map_for_arrow := function( a )
-      return CokernelFunctorial
+      return CokernelObjectFunctorial
              ( MapForVertex( m, Source( a ) ),
                MapForArrow( Range( m ), a ),
                MapForVertex( m, Target( a ) ) );


### PR DESCRIPTION
CokernelFunctorial is deprecated by
https://github.com/homalg-project/CAP_project/pull/906.