### PR TITLE
Comply with GAP master

### DIFF
--- a/lib/nice-basis.gi
+++ b/lib/nice-basis.gi
@@ -35,7 +35,7 @@ InstallHandlingByNiceBasis( "IsSubspaceOfQuiverAlgebra",
        end ) );
 
 
-InstallMethod( NiceFreeLeftModule, [ IsSubspaceOfQuiverAlgebra ],
+InstallMethod( NiceFreeLeftModule, [ IsFreeLeftModule and IsSubspaceOfQuiverAlgebra ],
 function( V )
   local info;
   info := NiceFreeLeftModuleInfo( V );

--- a/lib/vecspace.gi
+++ b/lib/vecspace.gi
@@ -758,7 +758,7 @@ InstallHandlingByNiceBasis( "IsSubspaceOfQPAVectorSpace",
        end ) );
 
 
-InstallMethod( NiceFreeLeftModule, [ IsSubspaceOfQPAVectorSpace ],
+InstallMethod( NiceFreeLeftModule, [ IsFreeLeftModule and IsSubspaceOfQPAVectorSpace ],
 function( V )
   local info;
   info := NiceFreeLeftModuleInfo( V );


### PR DESCRIPTION
Since GAP commit 2f4a518d36912392d7102c940873e77b2c076c23, `IsSubspaceOfQuiverAlgebra` and `IsSubspaceOfQPAVectorSpace` do not imply `IsFreeLeftModule` anymore.

See https://github.com/gap-system/gap/issues/5322 for more context.