### PR TITLE
Explicitly set category_as_first_argument

### DIFF
--- a/lib/module.gi
+++ b/lib/module.gi
@@ -415,12 +415,14 @@ side -> function( rep_cat )
     A := algebras[ 1 ];
     B := algebras[ 2 ];
     cat := CreateCapCategory( Concatenation( "bimodules over ", String( A ), " and ", String( B ) ) );
+    cat!.category_as_first_argument := false;
     SetFilterObj( cat, IsQuiverBimoduleCategory );
   else
     A := rep_algebra^side;
     algebras := [ fail, fail ];
     algebras[ Int( side ) ] := A;
     cat := CreateCapCategory( Concatenation( String( side ), " modules over ", String( A ) ) );
+    cat!.category_as_first_argument := false;
     if side = LEFT then
       SetFilterObj( cat, IsLeftQuiverModuleCategory );
     else

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -908,6 +908,7 @@ function( A, vecspace_cat )
   Q := QuiverOfAlgebra( A );
 
   cat := CreateCapCategory( Concatenation( "quiver representations over ", String( A ) ) );
+  cat!.category_as_first_argument := false;
   SetFilterObj( cat, IsQuiverRepresentationCategory );
   SetAlgebraOfCategory( cat, A );
   SetVectorSpaceCategory( cat, vecspace_cat );

--- a/lib/stablecategory.gi
+++ b/lib/stablecategory.gi
@@ -74,6 +74,7 @@ function( C )
         to_be_finalized;
     
   cat := CreateCapCategory( Concatenation( Name( C ), " / proj" ) );
+  cat!.category_as_first_argument := false;
   SetFilterObj( cat, IsStableCategoryModuloProjectives );
   SetOriginalCategory( cat, C );
   SetUnderlyingField( cat, UnderlyingField( C ) );

--- a/lib/vecspace.gi
+++ b/lib/vecspace.gi
@@ -415,6 +415,7 @@ function( F )
         injection_direct_sum,  projection_direct_sum;
 
   cat := CreateCapCategory( Concatenation( "vector spaces over ", String( F ) ) );
+  cat!.category_as_first_argument := false;
   SetFilterObj( cat, IsVectorSpaceCategory );
   SetUnderlyingField( cat, F );
 


### PR DESCRIPTION
I would like to change the default value of this option in CAP to `true` in the future, so it has to be set explicitly to `false` for all packages currently using the default.