### PR TITLE
Add the category as first the first argument to all `Add*` methods

### DIFF
--- a/lib/module.gi
+++ b/lib/module.gi
@@ -415,14 +415,14 @@ side -> function( rep_cat )
     A := algebras[ 1 ];
     B := algebras[ 2 ];
     cat := CreateCapCategory( Concatenation( "bimodules over ", String( A ), " and ", String( B ) ) );
-    cat!.category_as_first_argument := false;
+    cat!.category_as_first_argument := true;
     SetFilterObj( cat, IsQuiverBimoduleCategory );
   else
     A := rep_algebra^side;
     algebras := [ fail, fail ];
     algebras[ Int( side ) ] := A;
     cat := CreateCapCategory( Concatenation( String( side ), " modules over ", String( A ) ) );
-    cat!.category_as_first_argument := false;
+    cat!.category_as_first_argument := true;
     if side = LEFT then
       SetFilterObj( cat, IsLeftQuiverModuleCategory );
     else
@@ -437,54 +437,54 @@ side -> function( rep_cat )
   SetIsAbelianCategoryWithEnoughInjectives( cat, true );
 
   AddIsEqualForObjects( cat,
-  function( M1, M2 )
+  function( category, M1, M2 )
     return IsEqualForObjects( _R( M1 ), _R( M2 ) );
   end );
 
   AddIsEqualForMorphisms( cat,
-  function( m1, m2 )
+  function( category, m1, m2 )
     return IsEqualForMorphisms( _r( m1 ), _r( m2 ) );
   end );
 
-  AddZeroObject( cat, function()
+  AddZeroObject( cat, function( category )
     return _M( ZeroObject( rep_cat ) );
   end );
-  AddZeroMorphism( cat, function( M1, M2 )
+  AddZeroMorphism( cat, function( category, M1, M2 )
     return _m( ZeroMorphism( _R( M1 ), _R( M2 ) ) );
   end );
-  AddIdentityMorphism( cat, M -> _m( IdentityMorphism( _R( M ) ) ) );
-  AddPreCompose( cat, function( m1, m2 )
+  AddIdentityMorphism( cat, { category, M } -> _m( IdentityMorphism( _R( M ) ) ) );
+  AddPreCompose( cat, function( category, m1, m2 )
     return _m( PreCompose( _r( m1 ), _r( m2 ) ) );
   end );
-  AddAdditionForMorphisms( cat, function( m1, m2 )
+  AddAdditionForMorphisms( cat, function( category, m1, m2 )
     return _m( AdditionForMorphisms( _r( m1 ), _r( m2 ) ) );
   end );
-  AddAdditiveInverseForMorphisms( cat, m -> _m( AdditiveInverseForMorphisms( _r( m ) ) ) );
-  AddKernelEmbedding( cat, m -> _m( KernelEmbedding( _r( m ) ) ) );
-  AddCokernelProjection( cat, m -> _m( CokernelProjection( _r( m ) ) ) );
-  AddLiftAlongMonomorphism( cat, function( i, test )
+  AddAdditiveInverseForMorphisms( cat, { category, m } -> _m( AdditiveInverseForMorphisms( _r( m ) ) ) );
+  AddKernelEmbedding( cat, { category, m } -> _m( KernelEmbedding( _r( m ) ) ) );
+  AddCokernelProjection( cat, { category, m } -> _m( CokernelProjection( _r( m ) ) ) );
+  AddLiftAlongMonomorphism( cat, function( category, i, test )
     return _m( LiftAlongMonomorphism( _r( i ), _r( test ) ) );
   end );
-  AddColiftAlongEpimorphism( cat, function( e, test )
+  AddColiftAlongEpimorphism( cat, function( category, e, test )
     return _m( ColiftAlongEpimorphism( _r( e ), _r( test ) ) );
   end );
-  AddProjectiveLift( cat, function( pi, epsilon )
+  AddProjectiveLift( cat, function( category, pi, epsilon )
     return _m( ProjectiveLift( _r( pi ), _r( epsilon ) ) );
   end );
-  AddDirectSum( cat, function( summands )
+  AddDirectSum( cat, function( category, summands )
     return _M( DirectSum( List( summands, _R ) ) );
   end );
-  AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, function( summands, i, sum )
+  AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, function( category, summands, i, sum )
     return _m( InjectionOfCofactorOfDirectSumWithGivenDirectSum
                ( List( summands, _R ), i, _R( sum ) ) );
   end );
-  AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat, function( summands, i, sum )
+  AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat, function( category, summands, i, sum )
     return _m( ProjectionInFactorOfDirectSumWithGivenDirectSum
                ( List( summands, _R ), i, _R( sum ) ) );
   end );
 
-  AddEpimorphismFromSomeProjectiveObject( cat, ProjectiveCover );
-  AddMonomorphismIntoSomeInjectiveObject( cat, InjectiveEnvelope );
+  AddEpimorphismFromSomeProjectiveObject( cat, { category, m } -> ProjectiveCover( m ) );
+  AddMonomorphismIntoSomeInjectiveObject( cat, { category, m } -> InjectiveEnvelope( m ) );
 
   Finalize( cat );
 

--- a/lib/representation.gi
+++ b/lib/representation.gi
@@ -908,7 +908,7 @@ function( A, vecspace_cat )
   Q := QuiverOfAlgebra( A );
 
   cat := CreateCapCategory( Concatenation( "quiver representations over ", String( A ) ) );
-  cat!.category_as_first_argument := false;
+  cat!.category_as_first_argument := true;
   SetFilterObj( cat, IsQuiverRepresentationCategory );
   SetAlgebraOfCategory( cat, A );
   SetVectorSpaceCategory( cat, vecspace_cat );
@@ -917,7 +917,7 @@ function( A, vecspace_cat )
   SetIsAbelianCategoryWithEnoughProjectives( cat, true );
   SetIsAbelianCategoryWithEnoughInjectives( cat, true );
 
-  equal_objects := function( R1, R2 )
+  equal_objects := function( category, R1, R2 )
     return AlgebraOfRepresentation( R1 ) = AlgebraOfRepresentation( R2 ) and
            DimensionVector( R1 ) = DimensionVector( R2 ) and
            ForAll( ListN( VectorSpacesOfRepresentation( R1 ),
@@ -931,7 +931,7 @@ function( A, vecspace_cat )
   end;
   AddIsEqualForObjects( cat, equal_objects );
 
-  equal_morphisms := function( m1, m2 )
+  equal_morphisms := function( category, m1, m2 )
     return ForAll( ListN( MapsOfRepresentationHomomorphism( m1 ),
                           MapsOfRepresentationHomomorphism( m2 ),
                           IsEqualForMorphisms),
@@ -939,14 +939,14 @@ function( A, vecspace_cat )
   end;
   AddIsEqualForMorphisms( cat, equal_morphisms );
 
-  zero_object := function()
+  zero_object := function( category )
     local zero;
     zero := ZeroObject( vecspace_cat );
     return QuiverRepresentation( cat, List( Vertices( Q ), v -> zero ), [] );
   end;
   AddZeroObject( cat, zero_object );
 
-  zero_morphism := function( R1, R2 )
+  zero_morphism := function( category, R1, R2 )
     return QuiverRepresentationHomomorphism
            ( R1, R2,
              ListN( VectorSpacesOfRepresentation( R1 ),
@@ -957,7 +957,7 @@ function( A, vecspace_cat )
 
   # TODO: need IsZeroForMorphisms?
 
-  identity_morphism := function( R )
+  identity_morphism := function( category, R )
     return QuiverRepresentationHomomorphism
            ( R, R,
              List( VectorSpacesOfRepresentation( R ),
@@ -965,7 +965,7 @@ function( A, vecspace_cat )
   end;
   AddIdentityMorphism( cat, identity_morphism );
 
-  pre_compose := function( m1, m2 )
+  pre_compose := function( category, m1, m2 )
     return QuiverRepresentationHomomorphism
            ( Source( m1 ), Range( m2 ),
              ListN( MapsOfRepresentationHomomorphism( m1 ),
@@ -974,7 +974,7 @@ function( A, vecspace_cat )
   end;
   AddPreCompose( cat, pre_compose );
 
-  addition := function( m1, m2 )
+  addition := function( category, m1, m2 )
     return QuiverRepresentationHomomorphism
            ( Source( m1 ), Range( m1 ),
              ListN( MapsOfRepresentationHomomorphism( m1 ),
@@ -983,7 +983,7 @@ function( A, vecspace_cat )
   end;
   AddAdditionForMorphisms( cat, addition );
 
-  additive_inverse := function( m )
+  additive_inverse := function( category, m )
     return QuiverRepresentationHomomorphism
            ( Source( m ), Range( m ),
              List( MapsOfRepresentationHomomorphism( m ),
@@ -991,7 +991,7 @@ function( A, vecspace_cat )
   end;
   AddAdditiveInverseForMorphisms( cat, additive_inverse );
 
-  kernel_emb := function( m )
+  kernel_emb := function( category, m )
     local emb_maps, ker_objs, map_for_arrow, ker;
     emb_maps := List( MapsOfRepresentationHomomorphism( m ),
                       KernelEmbedding );
@@ -1009,7 +1009,7 @@ function( A, vecspace_cat )
   end;
   AddKernelEmbedding( cat, kernel_emb );
 
-  coker := function( m )
+  coker := function( category, m )
     local map_for_arrow;
     map_for_arrow := function( a )
       return CokernelObjectFunctorial
@@ -1024,15 +1024,15 @@ function( A, vecspace_cat )
              List( Arrows( Q ),
                    map_for_arrow ) );
   end;
-  coker_proj := function( m )
+  coker_proj := function( category, m )
     return QuiverRepresentationHomomorphism
-           ( Range( m ), coker( m ),
+           ( Range( m ), coker( CapCategory( m ), m ),
              List( MapsOfRepresentationHomomorphism( m ),
                    CokernelProjection ) );
   end;
   AddCokernelProjection( cat, coker_proj );
 
-  mono_lift := function( i, test )
+  mono_lift := function( category, i, test )
     return QuiverRepresentationHomomorphism
            ( Source( test ), Source( i ),
              ListN( MapsOfRepresentationHomomorphism( i ),
@@ -1041,7 +1041,7 @@ function( A, vecspace_cat )
   end;
   AddLiftAlongMonomorphism( cat, mono_lift );
 
-  epi_colift := function( e, test )
+  epi_colift := function( category, e, test )
     return QuiverRepresentationHomomorphism
            ( Range( e ), Range( test ),
              ListN( MapsOfRepresentationHomomorphism( e ),
@@ -1050,7 +1050,7 @@ function( A, vecspace_cat )
   end;
   AddColiftAlongEpimorphism( cat, epi_colift );
 
-  proj_lift := function( pi, epsilon )
+  proj_lift := function( category, pi, epsilon )
     local P, A, B, top_basis, images;
     P := Source( pi );
     A := Range( pi );
@@ -1062,7 +1062,7 @@ function( A, vecspace_cat )
   end;
   AddProjectiveLift( cat, proj_lift );
 
-  direct_sum := function( summands )
+  direct_sum := function( category, summands )
     return QuiverRepresentation
            ( cat,
              List( Transpose( List( summands,
@@ -1074,7 +1074,7 @@ function( A, vecspace_cat )
   end;
   AddDirectSum( cat, direct_sum );
 
-  direct_sum_inj := function( summands, i, sum )
+  direct_sum_inj := function( category, summands, i, sum )
     local map_for_vertex;
     map_for_vertex := function( v )
       return InjectionOfCofactorOfDirectSumWithGivenDirectSum
@@ -1088,7 +1088,7 @@ function( A, vecspace_cat )
   end;
   AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, direct_sum_inj );
   
-  direct_sum_proj := function( summands, i, sum )
+  direct_sum_proj := function( category, summands, i, sum )
     local map_for_vertex;
     map_for_vertex := function( v )
       return ProjectionInFactorOfDirectSumWithGivenDirectSum
@@ -1102,12 +1102,12 @@ function( A, vecspace_cat )
   end;
   AddProjectionInFactorOfDirectSumWithGivenDirectSum( cat, direct_sum_proj );
   
-  AddEpimorphismFromSomeProjectiveObject( cat, ProjectiveCover );
-  AddMonomorphismIntoSomeInjectiveObject( cat, InjectiveEnvelope );
+  AddEpimorphismFromSomeProjectiveObject( cat, { category, m } -> ProjectiveCover( m ) );
+  AddMonomorphismIntoSomeInjectiveObject( cat, { category, m } -> InjectiveEnvelope( m ) );
   
   ##
   AddIsWellDefinedForObjects( cat,
-    function( R )
+    function( category, R )
       local A, relations;
       
       A := AlgebraOfRepresentation( R );
@@ -1120,7 +1120,7 @@ function( A, vecspace_cat )
   
   ##
   AddIsWellDefinedForMorphisms( cat,
-    function( alpha )
+    function( category, alpha )
       local S, R, arrows;
       
       S := Source( alpha );

--- a/lib/stablecategory.gi
+++ b/lib/stablecategory.gi
@@ -74,17 +74,17 @@ function( C )
         to_be_finalized;
     
   cat := CreateCapCategory( Concatenation( Name( C ), " / proj" ) );
-  cat!.category_as_first_argument := false;
+  cat!.category_as_first_argument := true;
   SetFilterObj( cat, IsStableCategoryModuloProjectives );
   SetOriginalCategory( cat, C );
   SetUnderlyingField( cat, UnderlyingField( C ) );
   
-  equal_objects := function( R1, R2 )
+  equal_objects := function( category, R1, R2 )
       return OriginalObject( R1 ) = OriginalObject( R2 );
   end;
   AddIsEqualForObjects( cat, equal_objects );
   
-  equal_morphisms := function( m1, m2 )
+  equal_morphisms := function( category, m1, m2 )
       local p;
       p := StableHomProjection( Hom( Source( m1 ), Range( m2 ) ) );
       
@@ -92,32 +92,32 @@ function( C )
   end;
   AddIsEqualForMorphisms( cat, equal_morphisms );
 
-  zero_object := function()
+  zero_object := function( category )
     return AsStableCategoryObject( ZeroObject( C ), cat );
   end;
   AddZeroObject( cat, zero_object );
 
-  zero_morphism := function( R1, R2 )
+  zero_morphism := function( category, R1, R2 )
     return AsStableCategoryMorphism( ZeroMorphism( OriginalObject( R1 ), OriginalObject( R2 ) ), cat );
   end;
   AddZeroMorphism( cat, zero_morphism );
 
-  identity_morphism := function( R )
+  identity_morphism := function( category, R )
     return AsStableCategoryMorphism( IdentityMorphism( OriginalObject( R ) ), cat ); 
   end;
   AddIdentityMorphism( cat, identity_morphism );
 
-  pre_compose := function( m1, m2 )
+  pre_compose := function( category, m1, m2 )
       return AsStableCategoryMorphism( PreCompose( OriginalMorphism( m1 ), OriginalMorphism( m2 ) ), cat );
   end;
   AddPreCompose( cat, pre_compose );
 
-  addition := function( m1, m2 )
+  addition := function( category, m1, m2 )
       return AsStableCategoryMorphism( AdditionForMorphisms( OriginalMorphism( m1 ), OriginalMorphism( m2 ) ), cat );
   end;
   AddAdditionForMorphisms( cat, addition );
 
-  additive_inverse := function( m )
+  additive_inverse := function( category, m )
       return AsStableCategoryMorphism( AdditiveInverseForMorphisms( OriginalMorphism( m ) ), cat );
   end;
   AddAdditiveInverseForMorphisms( cat, additive_inverse );
@@ -128,12 +128,12 @@ function( C )
   # ColiftAlongEpimorphism. 
   #
 
-  direct_sum := function( summands )
+  direct_sum := function( category, summands )
       return AsStableCategoryObject( DirectSum( List( summands, OriginalObject ) ), cat );
   end;
   AddDirectSum( cat, direct_sum );
 
-  direct_sum_inj := function( summands, i, sum )
+  direct_sum_inj := function( category, summands, i, sum )
       local   h;
       
       h := InjectionOfCofactorOfDirectSumWithGivenDirectSum
@@ -143,7 +143,7 @@ function( C )
   end;
   AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, direct_sum_inj );
   
-  direct_sum_proj := function( summands, i, sum )
+  direct_sum_proj := function( category, summands, i, sum )
       local   h;
       
       h := ProjectionInFactorOfDirectSumWithGivenDirectSum

--- a/lib/vecspace.gi
+++ b/lib/vecspace.gi
@@ -415,38 +415,38 @@ function( F )
         injection_direct_sum,  projection_direct_sum;
 
   cat := CreateCapCategory( Concatenation( "vector spaces over ", String( F ) ) );
-  cat!.category_as_first_argument := false;
+  cat!.category_as_first_argument := true;
   SetFilterObj( cat, IsVectorSpaceCategory );
   SetUnderlyingField( cat, F );
 
   SetIsAbelianCategory( cat, true );
 
-  AddIsEqualForObjects( cat, \= );
-  AddIsEqualForMorphisms( cat, \= );
+  AddIsEqualForObjects( cat, { category, m1, m2 } -> m1 = m2 );
+  AddIsEqualForMorphisms( cat, { category, m1, m2 } -> m1 = m2 );
 
-  zero_object := function()
+  zero_object := function( category )
     return ZeroVectorSpace( F );
   end;
   AddZeroObject( cat, zero_object );
 
-  zero_morphism := function( V1, V2 )
+  zero_morphism := function( category, V1, V2 )
     return LinearTransformationByRightMatrix
            ( V1, V2, MakeZeroMatrix( F, Dimension( V1 ), Dimension( V2 ) ) );
   end;
   AddZeroMorphism( cat, zero_morphism );
 
-  is_zero_morphism := function( m )
+  is_zero_morphism := function( category, m )
     return IsZero( RightMatrixOfLinearTransformation( m ) );
   end;
   AddIsZeroForMorphisms( cat, is_zero_morphism );
 
-  identity_morphism := function( V )
+  identity_morphism := function( category, V )
     return LinearTransformationByRightMatrix
            ( V, V, IdentityMatrix( F, Dimension( V ) ) );
   end;
   AddIdentityMorphism( cat, identity_morphism );
 
-  pre_compose := function( m1, m2 )
+  pre_compose := function( category, m1, m2 )
     return LinearTransformationByRightMatrix
            ( Source( m1 ), Range( m2 ),
              RightMatrixOfLinearTransformation( m1 ) *
@@ -454,7 +454,7 @@ function( F )
   end;
   AddPreCompose( cat, pre_compose );
 
-  addition := function( m1, m2 )
+  addition := function( category, m1, m2 )
     return LinearTransformationByRightMatrix
            ( Source( m1 ), Range( m1 ),
              RightMatrixOfLinearTransformation( m1 ) +
@@ -462,13 +462,13 @@ function( F )
   end;
   AddAdditionForMorphisms( cat, addition );
 
-  additive_inverse := function( m )
+  additive_inverse := function( category, m )
     return LinearTransformationByRightMatrix
            ( Source( m ), Range( m ), - RightMatrixOfLinearTransformation( m ) );
   end;
   AddAdditiveInverseForMorphisms( cat, additive_inverse );
 
-  kernel_emb := function( m )
+  kernel_emb := function( category, m )
     local kernel_mat, dim;
     kernel_mat := NullspaceMat( RightMatrixOfLinearTransformation( m ) );
     dim := DimensionsMat( kernel_mat )[ 1 ];
@@ -478,7 +478,7 @@ function( F )
   end;
   AddKernelEmbedding( cat, kernel_emb );
 
-  coker_proj := function( m )
+  coker_proj := function( category, m )
     local mat, coker_mat, dim;
     mat := RightMatrixOfLinearTransformation( m );
     coker_mat := TransposedMat( NullspaceMat( TransposedMat( mat ) ) );
@@ -488,10 +488,10 @@ function( F )
   end;
   AddCokernelProjection( cat, coker_proj );
 
-  mono_lift := function( i, test )
+  mono_lift := function( category, i, test )
     local matrix;
     if IsZero( Source( i ) ) or IsZero( Source( test ) ) then
-      return zero_morphism( Source( test ), Source( i ) );
+      return zero_morphism( CapCategory( test ), Source( test ), Source( i ) );
     fi;
     matrix := List( Basis( Source( test ) ),
                     v -> AsList( PreImagesRepresentative( i, ImageElm( test, v ) ) ) );
@@ -501,10 +501,10 @@ function( F )
   end;
   AddLiftAlongMonomorphism( cat, mono_lift );
 
-  epi_colift := function( e, test )
+  epi_colift := function( category, e, test )
     local matrix;
     if IsZero( Range( e ) ) or IsZero( Range( test ) ) then
-      return zero_morphism( Range( e ), Range( test ) );
+      return zero_morphism( CapCategory( e ), Range( e ), Range( test ) );
     fi;
     matrix := List( Basis( Range( e ) ),
                     v -> AsList( ImageElm( test,
@@ -515,12 +515,12 @@ function( F )
   end;
   AddColiftAlongEpimorphism( cat, epi_colift );
 
-  direct_sum := function( summands )
+  direct_sum := function( category, summands )
     return StandardVectorSpace( F, Sum( List( summands, Dimension ) ) );
   end;
   AddDirectSum( cat, direct_sum );
 
-  injection_direct_sum := function( summands, i, sum )
+  injection_direct_sum := function( category, summands, i, sum )
     local n, summands_before, summands_after, dim_before, dim_after, dim_i,
           m1, m2, m3, matrix;
     n := Length( summands );
@@ -538,7 +538,7 @@ function( F )
   end;
   AddInjectionOfCofactorOfDirectSumWithGivenDirectSum( cat, injection_direct_sum );
 
-  projection_direct_sum := function( summands, i, sum )
+  projection_direct_sum := function( category, summands, i, sum )
     local n, summands_before, summands_after, dim_before, dim_after, dim_i,
           m1, m2, m3, matrix;
     n := Length( summands );


### PR DESCRIPTION
This change ensures compatibility with future versions of CAP.

Original commit by @TKuh